### PR TITLE
fix: big horizontal bar at the top of the page

### DIFF
--- a/Extension/content/main.css
+++ b/Extension/content/main.css
@@ -1,4 +1,4 @@
-div[id="app"] > div > *, div[id="app"] > div > span > div > span > div > div{
+div[id="app"] > div > :not(#wa-popovers-bucket), div[id="app"] > div > span > div > span > div > div{
   top: 0 !important;
   width: 100% !important;
   max-width: 100vw !important;


### PR DESCRIPTION
#### What?

CSS is not my strongest language, but I identified that the issue mentioned in problem #2 is related to the 'div' with the ID 'wa-popovers-bucket'.

#### Why?

Implementing these changes eliminates the horizontal bar at the top of WhatsApp Web, effectively resolving issue #2.

#### How?

To address this, it's crucial to exempt the div with ID 'wa-popovers-bucket' from the fullscreen rules for all elements inside the "app" div.